### PR TITLE
Fix multiple writes to a BodyPart overwriting previous contents

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -4,7 +4,7 @@ package mailyak
 type BodyPart []byte
 
 func (w *BodyPart) Write(p []byte) (int, error) {
-	*w = p
+	*w = append(*w, p...)
 	return len(p), nil
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/smtp"
+	"strings"
 	"testing"
 )
 
@@ -13,19 +14,25 @@ func TestHTML(t *testing.T) {
 	tests := []struct {
 		name string
 		// Parameters.
-		data string
+		data []string
 	}{
-		{"Writer test", "Worst idea since someone said ‘yeah let’s take this suspiciously large wooden horse into Troy, statues are all the rage this season’."},
+		{"Writer test", []string{"Worst idea since someone said ‘yeah let’s take this suspiciously large wooden horse into Troy, statues are all the rage this season’."}},
+		{"Writer test multiple", []string{
+			"Worst idea since someone said ‘yeah let’s take this suspiciously large wooden horse into Troy, statues are all the rage this season’.",
+			"Am I jumping the gun, Baldrick, or are the words 'I have a cunning plan' marching with ill-deserved confidence in the direction of this conversation?",
+		}},
 	}
 	for _, tt := range tests {
 		mail := New("", smtp.PlainAuth("", "", "", ""))
 
-		if _, err := io.WriteString(mail.HTML(), tt.data); err != nil {
-			t.Errorf("%q. HTML() error = %v", tt.name, err)
-			continue
+		for _, data := range tt.data {
+			if _, err := io.WriteString(mail.HTML(), data); err != nil {
+				t.Errorf("%q. HTML() error = %v", tt.name, err)
+				continue
+			}
 		}
 
-		if !bytes.Equal([]byte(tt.data), mail.html) {
+		if !bytes.Equal([]byte(strings.Join(tt.data, "")), mail.html) {
 			t.Errorf("%q. HTML() = %v, want %v", tt.name, string(mail.html), tt.data)
 		}
 	}


### PR DESCRIPTION
Multiple successive calls to a BodyPart would overwrite the previous contents. Users of MailYak should not be forced to write a BodyPart in one go – when using different templating engines this becomes a real problem because users don’t have any way to influence the write behavior.

Still, a better way would be to just use a plain `bytes.Buffer` as the base (or instead of) the `BodyPart` implementation. When looking at the standard lib's implementation of `bytes.Buffer` (https://golang.org/src/bytes/buffer.go) one can see that it more gracefully handles growing buffers and GC pressure, has better efficiency and also uses a plain byte slice as the workhorse (like `BodyPart`). I have an implementation of that in a separate branch if you want to take a look.

I updated a single test case but only superficially – the case that I added fails when only adding the test case.