### PR TITLE
Add missing pointer receivers

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -48,7 +48,7 @@ func (m *MailYak) ClearAttachments() {
 
 // writeAttachments loops over the attachments, guesses their content-type and
 // writes the data as a line-broken base64 string (using the splitter mutator)
-func (m MailYak) writeAttachments(mixed partCreator, splitter writeWrapper) error {
+func (m *MailYak) writeAttachments(mixed partCreator, splitter writeWrapper) error {
 	h := make([]byte, sniffLen)
 
 	for _, item := range m.attachments {

--- a/mailyak.go
+++ b/mailyak.go
@@ -57,7 +57,7 @@ func New(host string, auth smtp.Auth) *MailYak {
 //
 // Attachments are read when Send() is called, and any errors will be returned
 // here.
-func (m MailYak) Send() error {
+func (m *MailYak) Send() error {
 	buf, err := m.buildMime()
 	if err != nil {
 		return err

--- a/mime.go
+++ b/mime.go
@@ -64,7 +64,7 @@ func (m *MailYak) buildMimeWithBoundaries(mb, ab string) (*bytes.Buffer, error) 
 }
 
 // writeHeaders writes the Mime-Version, Reply-To, From, To and Subject headers
-func (m MailYak) writeHeaders(buf io.Writer) {
+func (m *MailYak) writeHeaders(buf io.Writer) {
 
 	buf.Write([]byte(m.fromHeader()))
 	buf.Write([]byte("Mime-Version: 1.0\r\n"))
@@ -82,7 +82,7 @@ func (m MailYak) writeHeaders(buf io.Writer) {
 
 // fromHeader returns a correctly formatted From header, optionally with a name
 // component
-func (m MailYak) fromHeader() string {
+func (m *MailYak) fromHeader() string {
 	if m.fromName == "" {
 		return fmt.Sprintf("From: %s\r\n", m.fromAddr)
 	}
@@ -91,7 +91,7 @@ func (m MailYak) fromHeader() string {
 }
 
 // writeBody writes the text/plain and text/html mime parts
-func (m MailYak) writeBody(w io.Writer, boundary string) error {
+func (m *MailYak) writeBody(w io.Writer, boundary string) error {
 	alt := multipart.NewWriter(w)
 	defer alt.Close()
 


### PR DESCRIPTION
Several methods were not pointer receivers and I don't see why – not having them is prone to copy around a lot of objects. Did you have a good reason to not add them?