### PR TITLE
Make MailYak struct conform to the Stringer interface

### DIFF
--- a/mailyak.go
+++ b/mailyak.go
@@ -1,6 +1,7 @@
 package mailyak
 
 import (
+	"fmt"
 	"net/smtp"
 	"regexp"
 )
@@ -76,6 +77,17 @@ func (m MailYak) Send() error {
 	}
 
 	return nil
+}
+
+// String makes MailYak struct printable for debugging purposes (conforms to the Stringer interface).
+func (m *MailYak) String() string {
+	var att []string
+	for _, a := range m.attachments {
+		att = append(att, "{filename: "+a.filename+"}")
+	}
+	return fmt.Sprintf("&MailYak{from: %q, fromName: %q, html: %v bytes, plain: %v bytes, toAddrs: %v, bccAddrs: %v, subject: %q, host: %q, attachments (%v): %v, auth set: %v}",
+		m.fromAddr, m.fromName, len(m.HTML().String()), len(m.Plain().String()), m.toAddrs, m.bccAddrs, m.subject, m.host, len(att), att, m.auth != nil,
+	)
 }
 
 // HTML returns a BodyPart for the HTML email body

--- a/mailyak_test.go
+++ b/mailyak_test.go
@@ -1,0 +1,29 @@
+package mailyak
+
+import (
+	"fmt"
+	"net/smtp"
+	"strings"
+	"testing"
+)
+
+// TestMailYakStringer ensures MailYak struct conforms to the Stringer interface.
+func TestMailYakStringer(t *testing.T) {
+	mail := New("mail.host.com:25", smtp.PlainAuth("", "user", "pass", "mail.host.com"))
+	mail.From("from@example.org")
+	mail.FromName("From Example")
+	mail.To("to@exmaple.org")
+	mail.Bcc("bcc1@example.org", "bcc2@example.org")
+	mail.Subject("Test subject")
+	mail.ReplyTo("replies@example.org")
+	mail.HTML().Set("HTML part: this is just a test.")
+	mail.Plain().Set("Plain text part: this is also just a test.")
+	mail.Attach("test.html", strings.NewReader("<html><head></head></html>"))
+	mail.Attach("test2.html", strings.NewReader("<html><head></head></html>"))
+
+	want := "&MailYak{from: \"from@example.org\", fromName: \"From Example\", html: 31 bytes, plain: 42 bytes, toAddrs: [to@exmaple.org], bccAddrs: [bcc1@example.org bcc2@example.org], subject: \"Test subject\", host: \"mail.host.com:25\", attachments (2): [{filename: test.html} {filename: test2.html}], auth set: true}"
+	got := fmt.Sprintf("%+v", mail)
+	if got != want {
+		t.Errorf("MailYak.String() = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
I also added a test and made sure that no auth credentials are leaked when this is used to log a mail object via a logger.