### PR TITLE
Use a byte buffer as the `BodyPart` storage

### DIFF
--- a/mailyak.go
+++ b/mailyak.go
@@ -19,6 +19,8 @@ type Emailer interface {
 	Plain() *BodyPart
 }
 
+// MailYak holds all the necessary information to send an email.
+// It also implements the Emailer interface.
 type MailYak struct {
 	html  BodyPart
 	plain BodyPart

--- a/mime.go
+++ b/mime.go
@@ -105,16 +105,17 @@ func (m *MailYak) writeBody(w io.Writer, boundary string) error {
 
 		c := fmt.Sprintf("%s; charset=UTF-8", ctype)
 
-		part, err := alt.CreatePart(textproto.MIMEHeader{"Content-Type": {c}})
-		if err != nil {
+		part, err2 := alt.CreatePart(textproto.MIMEHeader{"Content-Type": {c}})
+		if err2 != nil {
+			err = err2
 			return
 		}
 
 		part.Write(data)
 	}
 
-	writePart("text/plain", m.plain)
-	writePart("text/html", m.html)
+	writePart("text/plain", m.plain.Bytes())
+	writePart("text/html", m.html.Bytes())
 
 	return err
 }

--- a/mime_test.go
+++ b/mime_test.go
@@ -154,10 +154,9 @@ func TestMailYakWriteBody(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		m := MailYak{
-			html:  []byte(tt.rHTML),
-			plain: []byte(tt.rPlain),
-		}
+		m := MailYak{}
+		m.HTML().WriteString(tt.rHTML)
+		m.Plain().WriteString(tt.rPlain)
 
 		w := &bytes.Buffer{}
 		if err := m.writeBody(w, tt.boundary); (err != nil) != tt.wantErr {
@@ -302,8 +301,6 @@ func TestMailYakBuildMime(t *testing.T) {
 
 	for _, tt := range tests {
 		m := &MailYak{
-			html:      tt.rHTML,
-			plain:     tt.rPlain,
 			toAddrs:   tt.rtoAddrs,
 			subject:   tt.rsubject,
 			fromAddr:  tt.rfromAddr,
@@ -311,6 +308,8 @@ func TestMailYakBuildMime(t *testing.T) {
 			replyTo:   tt.rreplyTo,
 			trimRegex: regex,
 		}
+		m.HTML().Write(tt.rHTML)
+		m.Plain().Write(tt.rPlain)
 
 		got, err := m.buildMimeWithBoundaries("mixed", "alt")
 		if (err != nil) != tt.wantErr {
@@ -392,8 +391,6 @@ func TestMailYakBuildMime_withAttachments(t *testing.T) {
 
 	for _, tt := range tests {
 		m := &MailYak{
-			html:        tt.rHTML,
-			plain:       tt.rPlain,
 			toAddrs:     tt.rtoAddrs,
 			subject:     tt.rsubject,
 			fromAddr:    tt.rfromAddr,
@@ -402,6 +399,8 @@ func TestMailYakBuildMime_withAttachments(t *testing.T) {
 			attachments: tt.rattachments,
 			trimRegex:   regex,
 		}
+		m.HTML().Write(tt.rHTML)
+		m.Plain().Write(tt.rPlain)
 
 		got, err := m.buildMimeWithBoundaries("mixed", "alt")
 		if (err != nil) != tt.wantErr {

--- a/package.go
+++ b/package.go
@@ -1,4 +1,4 @@
-// This library provides a simple interface for sending MIME compliant emails
+// Package mailyak provides a simple interface for sending MIME compliant emails
 // over SMTP.
 //
 // Attachments are fully supported (attach anything that implements io.Reader)

--- a/writer.go
+++ b/writer.go
@@ -1,19 +1,12 @@
 package mailyak
 
-// BodyPart is a byte slice that implements io.Writer
-type BodyPart []byte
+import "bytes"
 
-func (w *BodyPart) Write(p []byte) (int, error) {
-	*w = append(*w, p...)
-	return len(p), nil
-}
+// BodyPart is a buffer.
+type BodyPart struct{ bytes.Buffer }
 
-// String returns the byte slice as a string in fmt.Printx(), etc
-func (w BodyPart) String() string {
-	return string(w)
-}
-
-// Set accepts a string as the contents of a BodyPart
+// Set accepts a string as the contents of a BodyPart and replaces any existing data.
 func (w *BodyPart) Set(s string) {
-	*w = []byte(s)
+	w.Reset()
+	w.WriteString(s)
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -32,8 +32,8 @@ func TestHTML(t *testing.T) {
 			}
 		}
 
-		if !bytes.Equal([]byte(strings.Join(tt.data, "")), mail.html) {
-			t.Errorf("%q. HTML() = %v, want %v", tt.name, string(mail.html), tt.data)
+		if !bytes.Equal([]byte(strings.Join(tt.data, "")), mail.html.Bytes()) {
+			t.Errorf("%q. HTML() = %v, want %v", tt.name, string(mail.html.Bytes()), tt.data)
 		}
 	}
 }
@@ -55,8 +55,8 @@ func TestPlain(t *testing.T) {
 			continue
 		}
 
-		if !bytes.Equal([]byte(tt.data), mail.plain) {
-			t.Errorf("%q. Plain() = %v, want %v", tt.name, string(mail.plain), tt.data)
+		if !bytes.Equal([]byte(tt.data), mail.plain.Bytes()) {
+			t.Errorf("%q. Plain() = %v, want %v", tt.name, string(mail.plain.Bytes()), tt.data)
 		}
 	}
 }
@@ -83,7 +83,7 @@ func TestWritableString(t *testing.T) {
 			t.Errorf("%q. writable.String() = %v, want %v", tt.name, mail.plain.String(), tt.data)
 		}
 
-		if out := fmt.Sprintf("%v", mail.plain); out != tt.data {
+		if out := fmt.Sprintf("%v", mail.plain.String()); out != tt.data {
 			t.Errorf("%q. writable.String() via fmt.Sprintf = %v, want %v", tt.name, out, tt.data)
 		}
 	}
@@ -106,8 +106,8 @@ func TestPlain_String(t *testing.T) {
 			continue
 		}
 
-		if !bytes.Equal([]byte(tt.data), mail.plain) {
-			t.Errorf("%q. Plain() = %v, want %v", tt.name, string(mail.plain), tt.data)
+		if !bytes.Equal([]byte(tt.data), mail.plain.Bytes()) {
+			t.Errorf("%q. Plain() = %v, want %v", tt.name, string(mail.plain.Bytes()), tt.data)
 		}
 	}
 }


### PR DESCRIPTION
Also, the body parts embedded by value are ready to be used – don’t muck around with manual creation of these internal struct fields, just use the public API.