### PR TITLE
Make MailYak setters fluent

### DIFF
--- a/setters.go
+++ b/setters.go
@@ -14,7 +14,7 @@ package mailyak
 //	}
 //
 //	mail.To(tos...)
-func (m *MailYak) To(addrs ...string) {
+func (m *MailYak) To(addrs ...string) *MailYak {
 	m.toAddrs = []string{}
 
 	for _, addr := range addrs {
@@ -25,6 +25,7 @@ func (m *MailYak) To(addrs ...string) {
 
 		m.toAddrs = append(m.toAddrs, trimmed)
 	}
+	return m
 }
 
 // Bcc sets a list of blind carbon copy (BCC) addresses
@@ -41,7 +42,7 @@ func (m *MailYak) To(addrs ...string) {
 //	}
 //
 // 	mail.Bcc(bccs...)
-func (m *MailYak) Bcc(addrs ...string) {
+func (m *MailYak) Bcc(addrs ...string) *MailYak {
 	m.bccAddrs = []string{}
 
 	for _, addr := range addrs {
@@ -52,24 +53,29 @@ func (m *MailYak) Bcc(addrs ...string) {
 
 		m.bccAddrs = append(m.bccAddrs, trimmed)
 	}
+	return m
 }
 
 // From sets the sender email address
-func (m *MailYak) From(addr string) {
+func (m *MailYak) From(addr string) *MailYak {
 	m.fromAddr = addr
+	return m
 }
 
 // FromName sets the sender name
-func (m *MailYak) FromName(name string) {
+func (m *MailYak) FromName(name string) *MailYak {
 	m.fromName = name
+	return m
 }
 
 // ReplyTo sends the Reply-To email address
-func (m *MailYak) ReplyTo(addr string) {
+func (m *MailYak) ReplyTo(addr string) *MailYak {
 	m.replyTo = addr
+	return m
 }
 
 // Subject sets the email subject line
-func (m *MailYak) Subject(sub string) {
+func (m *MailYak) Subject(sub string) *MailYak {
 	m.subject = m.trimRegex.ReplaceAllString(sub, "")
+	return m
 }

--- a/setters_test.go
+++ b/setters_test.go
@@ -1,6 +1,8 @@
 package mailyak
 
 import (
+	"fmt"
+	"net/smtp"
 	"reflect"
 	"regexp"
 	"testing"
@@ -89,5 +91,16 @@ func TestMailYakBcc(t *testing.T) {
 		if !reflect.DeepEqual(m.bccAddrs, tt.want) {
 			t.Errorf("%q. MailYak.Bcc() = %v, want %v", tt.name, m.bccAddrs, tt.want)
 		}
+	}
+}
+
+func TestFluentMailYak(t *testing.T) {
+	mail := New("mail.host.com:25", smtp.PlainAuth("", "user", "pass", "mail.host.com"))
+	mail.From("from@example.org").FromName("From Example").To("to@exmaple.org").Bcc("bcc1@example.org", "bcc2@example.org")
+	mail.Subject("Test subject").ReplyTo("replies@example.org")
+	want := "&MailYak{from: \"from@example.org\", fromName: \"From Example\", html: 0 bytes, plain: 0 bytes, toAddrs: [to@exmaple.org], bccAddrs: [bcc1@example.org bcc2@example.org], subject: \"Test subject\", host: \"mail.host.com:25\", attachments (0): [], auth set: true}"
+	got := fmt.Sprintf("%+v", mail)
+	if got != want {
+		t.Errorf("MailYak.String() = %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
This cuts down on the number of lines to compose one email and is also backwards-compatible.

See an example in the test I added. No other tests were touched – all green.