### PR TITLE
Proposal: Add method to get the raw MIME data

### DIFF
--- a/mailyak.go
+++ b/mailyak.go
@@ -1,6 +1,7 @@
 package mailyak
 
 import (
+	"bytes"
 	"fmt"
 	"net/smtp"
 	"regexp"

--- a/mailyak.go
+++ b/mailyak.go
@@ -81,6 +81,15 @@ func (m *MailYak) Send() error {
 	return nil
 }
 
+// MimeBuf returns the buffer containing the RAW MIME data
+func (m *MailYak) MimeBuf() (*bytes.Buffer, error) {
+	buf, err := m.buildMime()
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
 // String makes MailYak struct printable for debugging purposes (conforms to the Stringer interface).
 func (m *MailYak) String() string {
 	var att []string

--- a/mime.go
+++ b/mime.go
@@ -78,6 +78,10 @@ func (m *MailYak) writeHeaders(buf io.Writer) {
 	for _, to := range m.toAddrs {
 		fmt.Fprintf(buf, "To: %s\r\n", to)
 	}
+
+	for _, bcc := range m.bccAddrs {
+		fmt.Fprintf(buf, "BCC: %s\r\n", bcc)
+	}
 }
 
 // fromHeader returns a correctly formatted From header, optionally with a name


### PR DESCRIPTION
Hi @domodwyer ,

First of all, thanks for your package. This is exactly what I needed, although for a different purpose.
I am mainly interested in the MIME data you generate and not so much sending the emails via SMTP.

We use Amazon SES to send our e-mails and use the Raw MIME sending function.
(See http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html#send-email-raw-mime )

I currently don't see a way to access the MIME data we need to send, so my proposal is to add a method on MailYak which returns the mime buffer you create before sending.

This is a pull request which does exactly that, I have just tested this on my fork and it works perfectly for AWS SES, so it will probably work for similar services as well. I think this will help a lot of people sending MIME messages using SES.

This leaves just one issue: I now create a mailyak object using:
```go
mailmsg := mailyak.New("", smtp.PlainAuth("", "", "", ""))
```
Which is quite ugly, I don't need the SMTP properties, but the constructor is required for trimRegex.
Maybe you can think of a new constructor if you decide to add this kind of method.

If you decide this is out of scope, I will continue using my own fork, but I think this would be a welcome addition to your package.