### PR TITLE
Added an opt-in flag to optionally include bcc headers

### DIFF
--- a/mailyak.go
+++ b/mailyak.go
@@ -15,17 +15,18 @@ type MailYak struct {
 	html  BodyPart
 	plain BodyPart
 
-	toAddrs     []string
-	ccAddrs     []string
-	bccAddrs    []string
-	subject     string
-	fromAddr    string
-	fromName    string
-	replyTo     string
-	attachments []attachment
-	auth        smtp.Auth
-	trimRegex   *regexp.Regexp
-	host        string
+	toAddrs        []string
+	ccAddrs        []string
+	bccAddrs       []string
+	subject        string
+	fromAddr       string
+	fromName       string
+	replyTo        string
+	attachments    []attachment
+	auth           smtp.Auth
+	trimRegex      *regexp.Regexp
+	host           string
+	writeBccHeader bool
 }
 
 // New returns an instance of MailYak using host as the SMTP server, and
@@ -42,9 +43,10 @@ type MailYak struct {
 //
 func New(host string, auth smtp.Auth) *MailYak {
 	return &MailYak{
-		host:      host,
-		auth:      auth,
-		trimRegex: regexp.MustCompile("\r?\n"),
+		host:           host,
+		auth:           auth,
+		trimRegex:      regexp.MustCompile("\r?\n"),
+		writeBccHeader: true,
 	}
 }
 

--- a/mailyak.go
+++ b/mailyak.go
@@ -46,7 +46,7 @@ func New(host string, auth smtp.Auth) *MailYak {
 		host:           host,
 		auth:           auth,
 		trimRegex:      regexp.MustCompile("\r?\n"),
-		writeBccHeader: true,
+		writeBccHeader: false,
 	}
 }
 

--- a/mime.go
+++ b/mime.go
@@ -98,8 +98,10 @@ func (m *MailYak) writeHeaders(buf io.Writer) error {
 		fmt.Fprintf(buf, "CC: %s\r\n", cc)
 	}
 
-	for _, bcc := range m.bccAddrs {
-		fmt.Fprintf(buf, "BCC: %s\r\n", bcc)
+	if m.writeBccHeader {
+		for _, bcc := range m.bccAddrs {
+			fmt.Fprintf(buf, "BCC: %s\r\n", bcc)
+		}
 	}
 
 	return nil

--- a/mime_test.go
+++ b/mime_test.go
@@ -69,11 +69,12 @@ func TestMailYakWriteHeaders(t *testing.T) {
 		// Test description.
 		name string
 		// Receiver fields.
-		rtoAddrs  []string
-		rccAddrs  []string
-		rbccAddrs []string
-		rsubject  string
-		rreplyTo  string
+		rtoAddrs        []string
+		rccAddrs        []string
+		rbccAddrs       []string
+		rsubject        string
+		rreplyTo        string
+		rwriteBccHeader bool
 		// Expected results.
 		wantBuf string
 	}{
@@ -84,6 +85,7 @@ func TestMailYakWriteHeaders(t *testing.T) {
 			[]string{},
 			"Test",
 			"help@itsallbroken.com",
+			true,
 			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nReply-To: help@itsallbroken.com\r\nSubject: Test\r\nTo: test@itsallbroken.com\r\n",
 		},
 		{
@@ -93,6 +95,7 @@ func TestMailYakWriteHeaders(t *testing.T) {
 			[]string{},
 			"",
 			"",
+			true,
 			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nSubject: \r\nTo: test@itsallbroken.com\r\n",
 		},
 		{
@@ -102,6 +105,7 @@ func TestMailYakWriteHeaders(t *testing.T) {
 			[]string{},
 			"",
 			"",
+			true,
 			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nSubject: \r\nTo: test@itsallbroken.com\r\nTo: repairs@itsallbroken.com\r\n",
 		},
 		{
@@ -111,6 +115,7 @@ func TestMailYakWriteHeaders(t *testing.T) {
 			[]string{},
 			"",
 			"",
+			true,
 			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nSubject: \r\nTo: test@itsallbroken.com\r\nTo: repairs@itsallbroken.com\r\nCC: cc@itsallbroken.com\r\n",
 		},
 		{
@@ -120,9 +125,9 @@ func TestMailYakWriteHeaders(t *testing.T) {
 			[]string{},
 			"",
 			"",
+			true,
 			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nSubject: \r\nTo: test@itsallbroken.com\r\nTo: repairs@itsallbroken.com\r\nCC: cc1@itsallbroken.com\r\nCC: cc2@itsallbroken.com\r\n",
 		},
-
 		{
 			"Single Bcc address, Multiple To addresses",
 			[]string{"test@itsallbroken.com", "repairs@itsallbroken.com"},
@@ -130,6 +135,7 @@ func TestMailYakWriteHeaders(t *testing.T) {
 			[]string{"bcc@itsallbroken.com"},
 			"",
 			"",
+			true,
 			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nSubject: \r\nTo: test@itsallbroken.com\r\nTo: repairs@itsallbroken.com\r\nBCC: bcc@itsallbroken.com\r\n",
 		},
 		{
@@ -139,7 +145,18 @@ func TestMailYakWriteHeaders(t *testing.T) {
 			[]string{"bcc1@itsallbroken.com", "bcc2@itsallbroken.com"},
 			"",
 			"",
+			true,
 			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nSubject: \r\nTo: test@itsallbroken.com\r\nTo: repairs@itsallbroken.com\r\nBCC: bcc1@itsallbroken.com\r\nBCC: bcc2@itsallbroken.com\r\n",
+		},
+		{
+			"Multiple Bcc addresses, Multiple To addresses",
+			[]string{"test@itsallbroken.com", "repairs@itsallbroken.com"},
+			[]string{},
+			[]string{"bcc1@itsallbroken.com", "bcc2@itsallbroken.com"},
+			"",
+			"",
+			false,
+			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nSubject: \r\nTo: test@itsallbroken.com\r\nTo: repairs@itsallbroken.com\r\n",
 		},
 		{
 			"All together now",
@@ -148,6 +165,7 @@ func TestMailYakWriteHeaders(t *testing.T) {
 			[]string{"bcc1@itsallbroken.com", "bcc2@itsallbroken.com"},
 			"",
 			"",
+			true,
 			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nSubject: \r\nTo: test@itsallbroken.com\r\nTo: repairs@itsallbroken.com\r\nCC: cc1@itsallbroken.com\r\nCC: cc2@itsallbroken.com\r\nBCC: bcc1@itsallbroken.com\r\nBCC: bcc2@itsallbroken.com\r\n",
 		},
 	}
@@ -157,13 +175,14 @@ func TestMailYakWriteHeaders(t *testing.T) {
 			t.Parallel()
 
 			m := MailYak{
-				toAddrs:  tt.rtoAddrs,
-				subject:  tt.rsubject,
-				fromAddr: "dom@itsallbroken.com",
-				fromName: "Dom",
-				replyTo:  tt.rreplyTo,
-				ccAddrs:  tt.rccAddrs,
-				bccAddrs: tt.rbccAddrs,
+				toAddrs:        tt.rtoAddrs,
+				subject:        tt.rsubject,
+				fromAddr:       "dom@itsallbroken.com",
+				fromName:       "Dom",
+				replyTo:        tt.rreplyTo,
+				ccAddrs:        tt.rccAddrs,
+				bccAddrs:       tt.rbccAddrs,
+				writeBccHeader: tt.rwriteBccHeader,
 			}
 
 			buf := &bytes.Buffer{}

--- a/setters.go
+++ b/setters.go
@@ -54,6 +54,16 @@ func (m *MailYak) Bcc(addrs ...string) {
 	}
 }
 
+// WriteBccHeader is an opt-in option to write Bcc headers
+//
+// If set to true Bcc addresses are visible in the header.
+// Otherwise, headers are hidden. Default is true.
+//
+// 	mail.WriteBccHeader(true)
+func (m *MailYak) WriteBccHeader(shouldWrite bool) {
+	m.writeBccHeader = shouldWrite
+}
+
 // Cc sets a list of carbon copy (CC) addresses.
 //
 // You can pass one or more addresses to this method, which are viewable to the other recipients.

--- a/setters.go
+++ b/setters.go
@@ -54,12 +54,23 @@ func (m *MailYak) Bcc(addrs ...string) {
 	}
 }
 
-// WriteBccHeader is an opt-in option to write Bcc headers
+// WriteBccHeader writes the BCC header to the MIME body when true. Defaults to
+// false.
 //
-// If set to true Bcc addresses are visible in the header.
-// Otherwise, headers are hidden. Default is true.
+// This is usually required when writing the MIME body to an email API such as
+// Amazon's SES, but can cause problems when sending emails via a SMTP server.
 //
-// 	mail.WriteBccHeader(true)
+// Specifically, RFC822 says:
+//
+// 		Some  systems  may choose to include the text of the "Bcc" field only in the
+// 		author(s)'s  copy,  while  others  may also include it in the text sent to
+// 		all those indicated in the "Bcc" list.
+//
+// This ambiguity can result in some SMTP servers not stripping the BCC header
+// and exposing the BCC addressees to recipients. For more information, see:
+//
+// 		https://github.com/domodwyer/mailyak/issues/14
+//
 func (m *MailYak) WriteBccHeader(shouldWrite bool) {
 	m.writeBccHeader = shouldWrite
 }


### PR DESCRIPTION
This PR is intended to fix issue #14.

It adds a new setter on the mailyak object to control wether or not bcc headers should be written.

```
mail.WriteBccHeader(false)
```

Default value is set to `true` to always write bcc headers and so, do not change the current behavior.

Unit tests have been done on the `writeHeaders` method, and manual checking have been done using reported issue example:
* If `WriteBccHeader` is set to true, all recipients will see the headers
* Otherwise, "Bcc recipients" do not see each other and "To" recipients do not see "Bcc" addresses