### PR TITLE
Add support for spaces in attachment filenames

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -71,7 +71,7 @@ func (m *MailYak) writeAttachments(mixed partCreator, splitter writeWrapper) err
 			return err
 		}
 
-		ctype := fmt.Sprintf("%s;\n\tfilename=%s", http.DetectContentType(h[:hLen]), item.filename)
+		ctype := fmt.Sprintf("%s;\n\tfilename=%q", http.DetectContentType(h[:hLen]), item.filename)
 
 		part, err := mixed.CreatePart(getMIMEHeader(item, ctype))
 		if err != nil {
@@ -103,14 +103,14 @@ func getMIMEHeader(a attachment, ctype string) textproto.MIMEHeader {
 	var header textproto.MIMEHeader
 
 	if a.inline {
-		disp = fmt.Sprintf("inline;\n\tfilename=%s", a.filename)
+		disp = fmt.Sprintf("inline;\n\tfilename=%q", a.filename)
 		header = textproto.MIMEHeader{
 			"Content-Type":              {ctype},
 			"Content-Disposition":       {disp},
 			"Content-Transfer-Encoding": {"base64"},
 		}
 	} else {
-		disp = fmt.Sprintf("attachment;\n\tfilename=%s", a.filename)
+		disp = fmt.Sprintf("attachment;\n\tfilename=%q", a.filename)
 		cid := fmt.Sprintf("<%s>", a.filename)
 		header = textproto.MIMEHeader{
 			"Content-Type":              {ctype},

--- a/attachments_test.go
+++ b/attachments_test.go
@@ -156,17 +156,25 @@ func TestMailYakWriteAttachments(t *testing.T) {
 		{
 			"Empty",
 			[]attachment{{"Empty", &bytes.Buffer{}, false}},
-			"text/plain; charset=utf-8;\n\tfilename=Empty",
-			"attachment;\n\tfilename=Empty",
+			"text/plain; charset=utf-8;\n\tfilename=\"Empty\"",
+			"attachment;\n\tfilename=\"Empty\"",
 			"",
 			false,
 		},
 		{
 			"Short string",
 			[]attachment{{"advice", strings.NewReader("Don't Panic"), false}},
-			"text/plain; charset=utf-8;\n\tfilename=advice",
-			"attachment;\n\tfilename=advice",
+			"text/plain; charset=utf-8;\n\tfilename=\"advice\"",
+			"attachment;\n\tfilename=\"advice\"",
 			"RG9uJ3QgUGFuaWM=",
+			false,
+		},
+		{
+			"Space in filename",
+			[]attachment{{"Empty with spaces", &bytes.Buffer{}, false}},
+			"text/plain; charset=utf-8;\n\tfilename=\"Empty with spaces\"",
+			"attachment;\n\tfilename=\"Empty with spaces\"",
+			"",
 			false,
 		},
 		{
@@ -181,8 +189,8 @@ func TestMailYakWriteAttachments(t *testing.T) {
 					false,
 				},
 			},
-			"text/plain; charset=utf-8;\n\tfilename=partyinvite.txt",
-			"attachment;\n\tfilename=partyinvite.txt",
+			"text/plain; charset=utf-8;\n\tfilename=\"partyinvite.txt\"",
+			"attachment;\n\tfilename=\"partyinvite.txt\"",
 			"SWYgQmFsZHJpY2sgc2VydmVkIGEgbWVhbCBhdCBIUSBoZSB3b3VsZCBiZSBhcnJlc3Rl" +
 				"ZCBmb3IgdGhlIGJpZ2dlc3QgbWFzcyBwb2lzb25pbmcgc2luY2UgTHVjcmV0aWEgQm9y" +
 				"Z2lhIGludml0ZWQgNTAwIGZyaWVuZHMgZm9yIGEgV2luZSBhbmQgQW50aHJheCBQYXJ0eS4=",
@@ -208,8 +216,8 @@ func TestMailYakWriteAttachments(t *testing.T) {
 					false,
 				},
 			},
-			"text/plain; charset=utf-8;\n\tfilename=qed.txt",
-			"attachment;\n\tfilename=qed.txt",
+			"text/plain; charset=utf-8;\n\tfilename=\"qed.txt\"",
+			"attachment;\n\tfilename=\"qed.txt\"",
 			"Tm93IGl0IGlzIHN1Y2ggYSBiaXphcnJlbHkgaW1wcm9iYWJsZSBjb2luY2lkZW5jZSB0a" +
 				"GF0IGFueXRoaW5nIHNvIG1pbmQtYm9nZ2xpbmdseSB1c2VmdWwgY291bGQgaGF2ZSBldm" +
 				"9sdmVkIHB1cmVseSBieSBjaGFuY2UgdGhhdCBzb21lIHRoaW5rZXJzIGhhdmUgY2hvc2V" +
@@ -230,16 +238,16 @@ func TestMailYakWriteAttachments(t *testing.T) {
 		{
 			"HTML",
 			[]attachment{{"name.html", strings.NewReader("<html><head></head></html>"), false}},
-			"text/html; charset=utf-8;\n\tfilename=name.html",
-			"attachment;\n\tfilename=name.html",
+			"text/html; charset=utf-8;\n\tfilename=\"name.html\"",
+			"attachment;\n\tfilename=\"name.html\"",
 			"PGh0bWw+PGhlYWQ+PC9oZWFkPjwvaHRtbD4=",
 			false,
 		},
 		{
 			"HTML - wrong extension",
 			[]attachment{{"name.png", strings.NewReader("<html><head></head></html>"), false}},
-			"text/html; charset=utf-8;\n\tfilename=name.png",
-			"attachment;\n\tfilename=name.png",
+			"text/html; charset=utf-8;\n\tfilename=\"name.png\"",
+			"attachment;\n\tfilename=\"name.png\"",
 			"PGh0bWw+PGhlYWQ+PC9oZWFkPjwvaHRtbD4=",
 			false,
 		},
@@ -248,16 +256,16 @@ func TestMailYakWriteAttachments(t *testing.T) {
 		{
 			"Empty inline",
 			[]attachment{{"Empty", &bytes.Buffer{}, true}},
-			"text/plain; charset=utf-8;\n\tfilename=Empty",
-			"inline;\n\tfilename=Empty",
+			"text/plain; charset=utf-8;\n\tfilename=\"Empty\"",
+			"inline;\n\tfilename=\"Empty\"",
 			"",
 			false,
 		},
 		{
 			"Short string inline",
 			[]attachment{{"advice", strings.NewReader("Don't Panic"), true}},
-			"text/plain; charset=utf-8;\n\tfilename=advice",
-			"inline;\n\tfilename=advice",
+			"text/plain; charset=utf-8;\n\tfilename=\"advice\"",
+			"inline;\n\tfilename=\"advice\"",
 			"RG9uJ3QgUGFuaWM=",
 			false,
 		},
@@ -273,8 +281,8 @@ func TestMailYakWriteAttachments(t *testing.T) {
 					true,
 				},
 			},
-			"text/plain; charset=utf-8;\n\tfilename=partyinvite.txt",
-			"inline;\n\tfilename=partyinvite.txt",
+			"text/plain; charset=utf-8;\n\tfilename=\"partyinvite.txt\"",
+			"inline;\n\tfilename=\"partyinvite.txt\"",
 			"SWYgQmFsZHJpY2sgc2VydmVkIGEgbWVhbCBhdCBIUSBoZSB3b3VsZCBiZSBhcnJlc3Rl" +
 				"ZCBmb3IgdGhlIGJpZ2dlc3QgbWFzcyBwb2lzb25pbmcgc2luY2UgTHVjcmV0aWEgQm9y" +
 				"Z2lhIGludml0ZWQgNTAwIGZyaWVuZHMgZm9yIGEgV2luZSBhbmQgQW50aHJheCBQYXJ0eS4=",
@@ -300,8 +308,8 @@ func TestMailYakWriteAttachments(t *testing.T) {
 					true,
 				},
 			},
-			"text/plain; charset=utf-8;\n\tfilename=qed.txt",
-			"inline;\n\tfilename=qed.txt",
+			"text/plain; charset=utf-8;\n\tfilename=\"qed.txt\"",
+			"inline;\n\tfilename=\"qed.txt\"",
 			"Tm93IGl0IGlzIHN1Y2ggYSBiaXphcnJlbHkgaW1wcm9iYWJsZSBjb2luY2lkZW5jZSB0a" +
 				"GF0IGFueXRoaW5nIHNvIG1pbmQtYm9nZ2xpbmdseSB1c2VmdWwgY291bGQgaGF2ZSBldm" +
 				"9sdmVkIHB1cmVseSBieSBjaGFuY2UgdGhhdCBzb21lIHRoaW5rZXJzIGhhdmUgY2hvc2V" +
@@ -322,16 +330,16 @@ func TestMailYakWriteAttachments(t *testing.T) {
 		{
 			"HTML inline",
 			[]attachment{{"name.html", strings.NewReader("<html><head></head></html>"), true}},
-			"text/html; charset=utf-8;\n\tfilename=name.html",
-			"inline;\n\tfilename=name.html",
+			"text/html; charset=utf-8;\n\tfilename=\"name.html\"",
+			"inline;\n\tfilename=\"name.html\"",
 			"PGh0bWw+PGhlYWQ+PC9oZWFkPjwvaHRtbD4=",
 			false,
 		},
 		{
 			"HTML - wrong extension inline",
 			[]attachment{{"name.png", strings.NewReader("<html><head></head></html>"), true}},
-			"text/html; charset=utf-8;\n\tfilename=name.png",
-			"inline;\n\tfilename=name.png",
+			"text/html; charset=utf-8;\n\tfilename=\"name.png\"",
+			"inline;\n\tfilename=\"name.png\"",
 			"PGh0bWw+PGhlYWQ+PC9oZWFkPjwvaHRtbD4=",
 			false,
 		},
@@ -387,8 +395,8 @@ func TestMailYakWriteAttachments_multipleAttachments(t *testing.T) {
 			[]attachment{{"name.txt", strings.NewReader("test"), false}},
 			[]testAttachment{
 				{
-					contentType: "text/plain; charset=utf-8;\n\tfilename=name.txt",
-					disposition: "attachment;\n\tfilename=name.txt",
+					contentType: "text/plain; charset=utf-8;\n\tfilename=\"name.txt\"",
+					disposition: "attachment;\n\tfilename=\"name.txt\"",
 					data:        *bytes.NewBufferString("dGVzdA=="),
 				},
 			},
@@ -402,13 +410,13 @@ func TestMailYakWriteAttachments_multipleAttachments(t *testing.T) {
 			},
 			[]testAttachment{
 				{
-					contentType: "text/plain; charset=utf-8;\n\tfilename=name.txt",
-					disposition: "attachment;\n\tfilename=name.txt",
+					contentType: "text/plain; charset=utf-8;\n\tfilename=\"name.txt\"",
+					disposition: "attachment;\n\tfilename=\"name.txt\"",
 					data:        *bytes.NewBufferString("dGVzdA=="),
 				},
 				{
-					contentType: "text/plain; charset=utf-8;\n\tfilename=different.txt",
-					disposition: "attachment;\n\tfilename=different.txt",
+					contentType: "text/plain; charset=utf-8;\n\tfilename=\"different.txt\"",
+					disposition: "attachment;\n\tfilename=\"different.txt\"",
 					data:        *bytes.NewBufferString("YW5vdGhlcg=="),
 				},
 			},
@@ -422,13 +430,13 @@ func TestMailYakWriteAttachments_multipleAttachments(t *testing.T) {
 			},
 			[]testAttachment{
 				{
-					contentType: "text/plain; charset=utf-8;\n\tfilename=name.txt",
-					disposition: "attachment;\n\tfilename=name.txt",
+					contentType: "text/plain; charset=utf-8;\n\tfilename=\"name.txt\"",
+					disposition: "attachment;\n\tfilename=\"name.txt\"",
 					data:        *bytes.NewBufferString("dGVzdA=="),
 				},
 				{
-					contentType: "text/html; charset=utf-8;\n\tfilename=html.txt",
-					disposition: "attachment;\n\tfilename=html.txt",
+					contentType: "text/html; charset=utf-8;\n\tfilename=\"html.txt\"",
+					disposition: "attachment;\n\tfilename=\"html.txt\"",
 					data:        *bytes.NewBufferString("PGh0bWw+PGhlYWQ+PC9oZWFkPjwvaHRtbD4="),
 				},
 			},
@@ -464,8 +472,8 @@ func TestMailYakWriteAttachments_multipleAttachments(t *testing.T) {
 			},
 			[]testAttachment{
 				{
-					contentType: "text/plain; charset=utf-8;\n\tfilename=550.txt",
-					disposition: "attachment;\n\tfilename=550.txt",
+					contentType: "text/plain; charset=utf-8;\n\tfilename=\"550.txt\"",
+					disposition: "attachment;\n\tfilename=\"550.txt\"",
 					data: *bytes.NewBufferString(
 						"TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gTWF1cmlzIHV0IG5pc" +
 							"2wgZmVsaXMuIEFlbmVhbiBmZWxpcyBqdXN0bywgZ3JhdmlkYSBlZ2V0IGxlbyBhbGlxdWV0LCBtb2xlc3RpZSBhbGlxdW" +
@@ -478,8 +486,8 @@ func TestMailYakWriteAttachments_multipleAttachments(t *testing.T) {
 					),
 				},
 				{
-					contentType: "text/plain; charset=utf-8;\n\tfilename=520.txt",
-					disposition: "attachment;\n\tfilename=520.txt",
+					contentType: "text/plain; charset=utf-8;\n\tfilename=\"520.txt\"",
+					disposition: "attachment;\n\tfilename=\"520.txt\"",
 					data: *bytes.NewBufferString(
 						"TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gRG9uZWMgZXUgdmVz" +
 							"dGlidWx1bSBkb2xvci4gTnVuYyBhYyBwb3N1ZXJlIGZlbGlzLCBhIG1hdHRpcyBsZW8uIER1aXMgZWxlbWVudHVtIHRl" +
@@ -525,8 +533,8 @@ func TestMailYakWriteAttachments_multipleAttachments(t *testing.T) {
 			},
 			[]testAttachment{
 				{
-					contentType: "text/plain; charset=utf-8;\n\tfilename=520.txt",
-					disposition: "attachment;\n\tfilename=520.txt",
+					contentType: "text/plain; charset=utf-8;\n\tfilename=\"520.txt\"",
+					disposition: "attachment;\n\tfilename=\"520.txt\"",
 					data: *bytes.NewBufferString(
 						"TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gRG9uZWMgZXUgdmVz" +
 							"dGlidWx1bSBkb2xvci4gTnVuYyBhYyBwb3N1ZXJlIGZlbGlzLCBhIG1hdHRpcyBsZW8uIER1aXMgZWxlbWVudHVtIHRl" +
@@ -539,8 +547,8 @@ func TestMailYakWriteAttachments_multipleAttachments(t *testing.T) {
 					),
 				},
 				{
-					contentType: "text/plain; charset=utf-8;\n\tfilename=550.txt",
-					disposition: "attachment;\n\tfilename=550.txt",
+					contentType: "text/plain; charset=utf-8;\n\tfilename=\"550.txt\"",
+					disposition: "attachment;\n\tfilename=\"550.txt\"",
 					data: *bytes.NewBufferString(
 						"TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gTWF1cmlzIHV0IG5p" +
 							"c2wgZmVsaXMuIEFlbmVhbiBmZWxpcyBqdXN0bywgZ3JhdmlkYSBlZ2V0IGxlbyBhbGlxdWV0LCBtb2xlc3RpZSBhbGlx" +
@@ -562,8 +570,8 @@ func TestMailYakWriteAttachments_multipleAttachments(t *testing.T) {
 			[]attachment{{"name.txt", strings.NewReader("test"), true}},
 			[]testAttachment{
 				{
-					contentType: "text/plain; charset=utf-8;\n\tfilename=name.txt",
-					disposition: "inline;\n\tfilename=name.txt",
+					contentType: "text/plain; charset=utf-8;\n\tfilename=\"name.txt\"",
+					disposition: "inline;\n\tfilename=\"name.txt\"",
 					data:        *bytes.NewBufferString("dGVzdA=="),
 				},
 			},
@@ -577,13 +585,13 @@ func TestMailYakWriteAttachments_multipleAttachments(t *testing.T) {
 			},
 			[]testAttachment{
 				{
-					contentType: "text/plain; charset=utf-8;\n\tfilename=name.txt",
-					disposition: "inline;\n\tfilename=name.txt",
+					contentType: "text/plain; charset=utf-8;\n\tfilename=\"name.txt\"",
+					disposition: "inline;\n\tfilename=\"name.txt\"",
 					data:        *bytes.NewBufferString("dGVzdA=="),
 				},
 				{
-					contentType: "text/plain; charset=utf-8;\n\tfilename=different.txt",
-					disposition: "inline;\n\tfilename=different.txt",
+					contentType: "text/plain; charset=utf-8;\n\tfilename=\"different.txt\"",
+					disposition: "inline;\n\tfilename=\"different.txt\"",
 					data:        *bytes.NewBufferString("YW5vdGhlcg=="),
 				},
 			},
@@ -597,13 +605,13 @@ func TestMailYakWriteAttachments_multipleAttachments(t *testing.T) {
 			},
 			[]testAttachment{
 				{
-					contentType: "text/plain; charset=utf-8;\n\tfilename=name.txt",
-					disposition: "attachment;\n\tfilename=name.txt",
+					contentType: "text/plain; charset=utf-8;\n\tfilename=\"name.txt\"",
+					disposition: "attachment;\n\tfilename=\"name.txt\"",
 					data:        *bytes.NewBufferString("dGVzdA=="),
 				},
 				{
-					contentType: "text/plain; charset=utf-8;\n\tfilename=different.txt",
-					disposition: "inline;\n\tfilename=different.txt",
+					contentType: "text/plain; charset=utf-8;\n\tfilename=\"different.txt\"",
+					disposition: "inline;\n\tfilename=\"different.txt\"",
 					data:        *bytes.NewBufferString("YW5vdGhlcg=="),
 				},
 			},
@@ -617,13 +625,13 @@ func TestMailYakWriteAttachments_multipleAttachments(t *testing.T) {
 			},
 			[]testAttachment{
 				{
-					contentType: "text/plain; charset=utf-8;\n\tfilename=name.txt",
-					disposition: "inline;\n\tfilename=name.txt",
+					contentType: "text/plain; charset=utf-8;\n\tfilename=\"name.txt\"",
+					disposition: "inline;\n\tfilename=\"name.txt\"",
 					data:        *bytes.NewBufferString("dGVzdA=="),
 				},
 				{
-					contentType: "text/html; charset=utf-8;\n\tfilename=html.txt",
-					disposition: "inline;\n\tfilename=html.txt",
+					contentType: "text/html; charset=utf-8;\n\tfilename=\"html.txt\"",
+					disposition: "inline;\n\tfilename=\"html.txt\"",
 					data:        *bytes.NewBufferString("PGh0bWw+PGhlYWQ+PC9oZWFkPjwvaHRtbD4="),
 				},
 			},
@@ -659,8 +667,8 @@ func TestMailYakWriteAttachments_multipleAttachments(t *testing.T) {
 			},
 			[]testAttachment{
 				{
-					contentType: "text/plain; charset=utf-8;\n\tfilename=550.txt",
-					disposition: "inline;\n\tfilename=550.txt",
+					contentType: "text/plain; charset=utf-8;\n\tfilename=\"550.txt\"",
+					disposition: "inline;\n\tfilename=\"550.txt\"",
 					data: *bytes.NewBufferString(
 						"TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gTWF1cmlzIHV0IG5pc" +
 							"2wgZmVsaXMuIEFlbmVhbiBmZWxpcyBqdXN0bywgZ3JhdmlkYSBlZ2V0IGxlbyBhbGlxdWV0LCBtb2xlc3RpZSBhbGlxdW" +
@@ -673,8 +681,8 @@ func TestMailYakWriteAttachments_multipleAttachments(t *testing.T) {
 					),
 				},
 				{
-					contentType: "text/plain; charset=utf-8;\n\tfilename=520.txt",
-					disposition: "inline;\n\tfilename=520.txt",
+					contentType: "text/plain; charset=utf-8;\n\tfilename=\"520.txt\"",
+					disposition: "inline;\n\tfilename=\"520.txt\"",
 					data: *bytes.NewBufferString(
 						"TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gRG9uZWMgZXUgdmVz" +
 							"dGlidWx1bSBkb2xvci4gTnVuYyBhYyBwb3N1ZXJlIGZlbGlzLCBhIG1hdHRpcyBsZW8uIER1aXMgZWxlbWVudHVtIHRl" +
@@ -720,8 +728,8 @@ func TestMailYakWriteAttachments_multipleAttachments(t *testing.T) {
 			},
 			[]testAttachment{
 				{
-					contentType: "text/plain; charset=utf-8;\n\tfilename=520.txt",
-					disposition: "inline;\n\tfilename=520.txt",
+					contentType: "text/plain; charset=utf-8;\n\tfilename=\"520.txt\"",
+					disposition: "inline;\n\tfilename=\"520.txt\"",
 					data: *bytes.NewBufferString(
 						"TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gRG9uZWMgZXUgdmVz" +
 							"dGlidWx1bSBkb2xvci4gTnVuYyBhYyBwb3N1ZXJlIGZlbGlzLCBhIG1hdHRpcyBsZW8uIER1aXMgZWxlbWVudHVtIHRl" +
@@ -734,8 +742,8 @@ func TestMailYakWriteAttachments_multipleAttachments(t *testing.T) {
 					),
 				},
 				{
-					contentType: "text/plain; charset=utf-8;\n\tfilename=550.txt",
-					disposition: "inline;\n\tfilename=550.txt",
+					contentType: "text/plain; charset=utf-8;\n\tfilename=\"550.txt\"",
+					disposition: "inline;\n\tfilename=\"550.txt\"",
 					data: *bytes.NewBufferString(
 						"TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gTWF1cmlzIHV0IG5p" +
 							"c2wgZmVsaXMuIEFlbmVhbiBmZWxpcyBqdXN0bywgZ3JhdmlkYSBlZ2V0IGxlbyBhbGlxdWV0LCBtb2xlc3RpZSBhbGlx" +

--- a/mime_test.go
+++ b/mime_test.go
@@ -574,9 +574,9 @@ func TestMailYakBuildMime_withAttachments(t *testing.T) {
 					// Check Disposition header
 					var disp string
 					if attch.inline {
-						disp = "inline; filename=%s"
+						disp = "inline; filename=%q"
 					} else {
-						disp = "attachment; filename=%s"
+						disp = "attachment; filename=%q"
 					}
 					if p.Header.Get("Content-Disposition") != fmt.Sprintf(disp, attch.filename) {
 						continue


### PR DESCRIPTION
As stated in the title, this PR adds in support for spaces in attachment filenames. 

I was writing a library to send emails through AWS SES earlier today, using Mailyak to create the raw MIME messages, and tried sending an email with an attachment that had a space in the filename, when I discovered that this resulted in an error occurring. After some googling I found that others usually suggest to quote the filename in MIME headers, and when I fixed that in my own fork I saw that I could now correctly send emails with such attachments.