### PR TITLE
Add ability to attach files with specified mime types

### DIFF
--- a/mime_test.go
+++ b/mime_test.go
@@ -472,7 +472,7 @@ func TestMailYakBuildMime_withAttachments(t *testing.T) {
 			"",
 			"",
 			[]attachment{
-				{"test.txt", strings.NewReader("content"), false},
+				{"test.txt", strings.NewReader("content"), false, ""},
 			},
 			[]string{"Y29udGVudA=="},
 			false,
@@ -487,7 +487,7 @@ func TestMailYakBuildMime_withAttachments(t *testing.T) {
 			"",
 			"",
 			[]attachment{
-				{"test.txt", strings.NewReader("content"), true},
+				{"test.txt", strings.NewReader("content"), true, ""},
 			},
 			[]string{"Y29udGVudA=="},
 			false,
@@ -502,8 +502,8 @@ func TestMailYakBuildMime_withAttachments(t *testing.T) {
 			"",
 			"",
 			[]attachment{
-				{"test.txt", strings.NewReader("content"), false},
-				{"another.txt", strings.NewReader("another"), false},
+				{"test.txt", strings.NewReader("content"), false, ""},
+				{"another.txt", strings.NewReader("another"), false, ""},
 			},
 			[]string{"Y29udGVudA==", "YW5vdGhlcg=="},
 			false,
@@ -518,8 +518,8 @@ func TestMailYakBuildMime_withAttachments(t *testing.T) {
 			"",
 			"",
 			[]attachment{
-				{"test.txt", strings.NewReader("content"), true},
-				{"another.txt", strings.NewReader("another"), true},
+				{"test.txt", strings.NewReader("content"), true, ""},
+				{"another.txt", strings.NewReader("another"), true, ""},
 			},
 			[]string{"Y29udGVudA==", "YW5vdGhlcg=="},
 			false,


### PR DESCRIPTION
Adds the attachWithMimeType dicussed in https://github.com/domodwyer/mailyak/issues/25 and also added a AttachInlineWithMimeType for parity.

Testing wise the new field in the attachment struct I defaulted to "" in a bunch of tests because its not important.  I added in 2 tests very similar to the existing ones that test the attachment slice length, I also added cases to the write attachments / write inline attachments tests to ensure the specified mime is being set.

I thought it would be handy on the original attach funcs to note in the comments how they handle the mime type given its quite important / to save digging around in the code.