### PR TITLE
Adding MIME headers

### DIFF
--- a/mailyak.go
+++ b/mailyak.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"net/smtp"
+	"net/textproto"
 	"regexp"
 	"time"
-	"net/textproto"
 )
 
 // TODO: in the future, when aliasing is supported or we're making a breaking
@@ -30,7 +30,7 @@ type MailYak struct {
 	host           string
 	writeBccHeader bool
 	date           string
-	headers map[string]string
+	headers        map[string]string
 }
 
 // New returns an instance of MailYak using host as the SMTP server, and
@@ -64,7 +64,7 @@ func GetMailYakForMime(headers textproto.MIMEHeader) *MailYak {
 
 	for k, _ := range headers {
 		if k != "Content-Type" && k != "Mime-Version" {
-			 my.headers[k] = headers.Get(k)
+			my.headers[k] = headers.Get(k)
 		}
 	}
 	return my

--- a/mailyak.go
+++ b/mailyak.go
@@ -55,13 +55,8 @@ func New(host string, auth smtp.Auth) *MailYak {
 	}
 }
 
-func GetMailYakForMime(subject string, to string, fromEmail string, fromName string, replyTo string, headers textproto.MIMEHeader) *MailYak {
+func GetMailYakForMime(headers textproto.MIMEHeader) *MailYak {
 	my := &MailYak{
-		toAddrs: []string{to},
-		fromAddr:fromEmail,
-		fromName: fromName,
-		replyTo: replyTo,
-		subject: subject,
 		trimRegex:      regexp.MustCompile("\r?\n"),
 		writeBccHeader: false,
 		date:           time.Now().Format(time.RFC1123Z),

--- a/mailyak.go
+++ b/mailyak.go
@@ -62,6 +62,7 @@ func GetMailYakForMime(headers textproto.MIMEHeader) *MailYak {
 		date:           time.Now().Format(time.RFC1123Z),
 	}
 
+	my.headers = make(map[string]string, 0)
 	for k, _ := range headers {
 		if k != "Content-Type" && k != "Mime-Version" {
 			my.headers[k] = headers.Get(k)

--- a/mime.go
+++ b/mime.go
@@ -96,7 +96,9 @@ func (m *MailYak) writeHeaders(buf io.Writer) error {
 		fmt.Fprintf(buf, "Reply-To: %s\r\n", m.replyTo)
 	}
 
-	fmt.Fprintf(buf, "Subject: %s\r\n", m.subject)
+	if m.subject != "" {
+		fmt.Fprintf(buf, "Subject: %s\r\n", m.subject)
+	}
 
 	for _, to := range m.toAddrs {
 		fmt.Fprintf(buf, "To: %s\r\n", to)

--- a/mime.go
+++ b/mime.go
@@ -76,8 +76,10 @@ func (m *MailYak) buildMimeWithBoundaries(mb, ab string) (*bytes.Buffer, error) 
 // writeHeaders writes the Mime-Version, Date, Reply-To, From, To and Subject headers.
 func (m *MailYak) writeHeaders(buf io.Writer) error {
 
-	if _, err := buf.Write([]byte(m.fromHeader())); err != nil {
-		return err
+	if m.fromAddr != "" {
+		if _, err := buf.Write([]byte(m.fromHeader())); err != nil {
+			return err
+		}
 	}
 
 	if _, err := buf.Write([]byte("Mime-Version: 1.0\r\n")); err != nil {

--- a/mime.go
+++ b/mime.go
@@ -86,6 +86,10 @@ func (m *MailYak) writeHeaders(buf io.Writer) error {
 
 	fmt.Fprintf(buf, "Date: %s\r\n", m.date)
 
+	for k, v := range m.headers {
+		buf.Write([]byte(k + ": " + v + "\r\n"))
+	}
+
 	if m.replyTo != "" {
 		fmt.Fprintf(buf, "Reply-To: %s\r\n", m.replyTo)
 	}


### PR DESCRIPTION
Might need some changes for sanity. But, this change enables users to add MIME headers like in the production emails you'd have. I had added it for our prod environment. Please suggest changes for generic MIME header addition