### PR TITLE
Change inline attachment headers.

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -144,11 +144,12 @@ func getMIMEHeader(a attachment, ctype string) textproto.MIMEHeader {
 	var header textproto.MIMEHeader
 
 	if a.inline {
-		disp = fmt.Sprintf("inline;\n\tfilename=%q", a.filename)
+		cid := fmt.Sprintf("<%s>", a.filename)
 		header = textproto.MIMEHeader{
 			"Content-Type":              {ctype},
-			"Content-Disposition":       {disp},
+			"Content-Disposition":       {"inline"},
 			"Content-Transfer-Encoding": {"base64"},
+			"Content-ID":                {cid},
 		}
 	} else {
 		disp = fmt.Sprintf("attachment;\n\tfilename=%q", a.filename)


### PR DESCRIPTION
Not sure if you actually want to merge this, but I had to make a fork and make this change locally to get inline image attachments to render properly in certain mail clients (Outlook for iOS, for one).

