### PR TITLE
#44 Add Content-ID for Inlined Attachments

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -143,16 +143,17 @@ func getMIMEHeader(a attachment, ctype string) textproto.MIMEHeader {
 	var disp string
 	var header textproto.MIMEHeader
 
+	cid := fmt.Sprintf("<%s>", a.filename)
 	if a.inline {
 		disp = fmt.Sprintf("inline;\n\tfilename=%q", a.filename)
 		header = textproto.MIMEHeader{
 			"Content-Type":              {ctype},
 			"Content-Disposition":       {disp},
 			"Content-Transfer-Encoding": {"base64"},
+			"Content-ID":                {cid},
 		}
 	} else {
 		disp = fmt.Sprintf("attachment;\n\tfilename=%q", a.filename)
-		cid := fmt.Sprintf("<%s>", a.filename)
 		header = textproto.MIMEHeader{
 			"Content-Type":              {ctype},
 			"Content-Disposition":       {disp},


### PR DESCRIPTION
This change set **Content-ID** same way for Inline and Non Inline Attachments, and should resolve #44 