### PR TITLE
mod: specify version in import path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/domodwyer/mailyak
+module github.com/domodwyer/mailyak/v3
 
 go 1.12


### PR DESCRIPTION
Go modules require the major version to be added to the end of the
module path after version 2:

     the go command requires that modules with major version v2 or later
     use a module path with that major version as the final element

https://golang.org/cmd/go/#hdr-Module_compatibility_and_semantic_versioning

Fixes #46