### PR TITLE
Update 'Date' timestamp before sending email

### DIFF
--- a/mailyak.go
+++ b/mailyak.go
@@ -33,6 +33,9 @@ type MailYak struct {
 	date           string
 }
 
+// Email Date timestamp format
+const mailDateFormat = time.RFC1123Z
+
 // New returns an instance of MailYak using host as the SMTP server, and
 // authenticating with auth where required.
 //
@@ -52,7 +55,7 @@ func New(host string, auth smtp.Auth) *MailYak {
 		auth:           auth,
 		trimRegex:      regexp.MustCompile("\r?\n"),
 		writeBccHeader: false,
-		date:           time.Now().Format(time.RFC1123Z),
+		date:           time.Now().Format(mailDateFormat),
 	}
 }
 
@@ -60,7 +63,9 @@ func New(host string, auth smtp.Auth) *MailYak {
 //
 // Attachments are read when Send() is called, and any connection/authentication
 // errors will be returned by Send().
+// Upon sending, the date timestamp will be updated to the current time.
 func (m *MailYak) Send() error {
+	m.date = time.Now().Format(mailDateFormat)
 	buf, err := m.buildMime()
 	if err != nil {
 		return err
@@ -80,6 +85,7 @@ func (m *MailYak) Send() error {
 // MimeBuf is typically used with an API service such as Amazon SES that does
 // not use an SMTP interface.
 func (m *MailYak) MimeBuf() (*bytes.Buffer, error) {
+	m.date = time.Now().Format(mailDateFormat)
 	buf, err := m.buildMime()
 	if err != nil {
 		return nil, err

--- a/mailyak_test.go
+++ b/mailyak_test.go
@@ -5,6 +5,7 @@ import (
 	"net/smtp"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestMailYakStringer ensures MailYak struct conforms to the Stringer interface.
@@ -31,5 +32,29 @@ func TestMailYakStringer(t *testing.T) {
 	got := fmt.Sprintf("%+v", mail)
 	if got != want {
 		t.Errorf("MailYak.String() = %v, want %v", got, want)
+	}
+}
+
+// TestMailYakDate ensures two emails sent with the same MailYak instance use
+// different (updated) date timestamps.
+func TestMailYakDate(t *testing.T) {
+	t.Parallel()
+
+	mail := New("mail.host.com:25", smtp.PlainAuth("", "user", "pass", "mail.host.com"))
+	mail.From("from@example.org")
+	mail.To("to@example.org")
+	mail.Subject("Test subject")
+
+	// send two emails at different times (discard any errors)
+	mail.Send()
+	dateOne := mail.date
+
+	time.Sleep(1 * time.Second)
+
+	mail.Send()
+	dateTwo := mail.date
+
+	if dateOne == dateTwo {
+		t.Errorf("MailYak.Send(): timestamp not updated: %v", dateOne)
 	}
 }


### PR DESCRIPTION
As discussed in
https://github.com/domodwyer/mailyak/issues/50#issuecomment-720597806
the library should automatically updated the date timestamp before
sending out emails, otherwise re-using the MailYak instance (over
longer periods of time) leads to stale timestamps.

With this patch, the timestamp is automatically updated in Send() and
MimeBuf() methods. It also adds a testcase for this scenario.

Closes #50 