### PR TITLE
fix: include content type in empty MIME parts

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -60,6 +60,18 @@ func TestIntegration_TLS(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "empty",
+			fn: func(m *MailYak) {
+				m.From("from@example.org")
+				m.FromName("From Example")
+				m.To("dom@eitsallbroken.com")
+				m.Bcc("bcc1@example.org", "bcc2@example.org")
+				m.Subject("TLS empty")
+				m.ReplyTo("replies@example.org")
+			},
+			wantErr: nil,
+		},
+		{
 			name: "authenticated",
 			auth: smtp.PlainAuth("ident", "user", "pass", "127.0.0.1"),
 			fn: func(m *MailYak) {
@@ -90,7 +102,7 @@ func TestIntegration_TLS(t *testing.T) {
 				m.To("to@example.org")
 				m.Subject("TLS Attachment test")
 				m.ReplyTo("replies@example.org")
-				m.HTML().Set("Attachment MF5: " + hashString)
+				m.HTML().Set("Attachment MD5: " + hashString)
 				m.Attach("test.bin", bytes.NewReader(data))
 			},
 			wantErr: nil,
@@ -153,6 +165,18 @@ func TestIntegration_PlainText(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "empty",
+			fn: func(m *MailYak) {
+				m.From("from@example.org")
+				m.FromName("From Example")
+				m.To("dom@eitsallbroken.com")
+				m.Bcc("bcc1@example.org", "bcc2@example.org")
+				m.Subject("Plaintext empty")
+				m.ReplyTo("replies@example.org")
+			},
+			wantErr: nil,
+		},
+		{
 			name: "authenticated",
 			auth: smtp.PlainAuth("ident", "user", "pass", "127.0.0.1"),
 			fn: func(m *MailYak) {
@@ -183,7 +207,7 @@ func TestIntegration_PlainText(t *testing.T) {
 				m.To("to@example.org")
 				m.Subject("PLAIN - Attachment test")
 				m.ReplyTo("replies@example.org")
-				m.HTML().Set("Attachment MF5: " + hashString)
+				m.HTML().Set("Attachment MD5: " + hashString)
 				m.Attach("test.bin", bytes.NewReader(data))
 			},
 			wantErr: nil,

--- a/mailyak_test.go
+++ b/mailyak_test.go
@@ -46,12 +46,12 @@ func TestMailYakDate(t *testing.T) {
 	mail.Subject("Test subject")
 
 	// send two emails at different times (discarding any errors)
-	_ = mail.Send()
+	_, _ = mail.MimeBuf()
 	dateOne := mail.date
 
 	time.Sleep(1 * time.Second)
 
-	_ = mail.Send()
+	_, _ = mail.MimeBuf()
 	dateTwo := mail.date
 
 	if dateOne == dateTwo {

--- a/mime.go
+++ b/mime.go
@@ -143,7 +143,7 @@ func (m *MailYak) writeBody(w io.Writer, boundary string) error {
 
 	var err error
 	writePart := func(ctype string, data []byte) {
-		if len(data) == 0 || err != nil {
+		if err != nil {
 			return
 		}
 

--- a/mime_test.go
+++ b/mime_test.go
@@ -217,11 +217,11 @@ func TestMailYakWriteBody(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			"Boundary name",
+			"Empty",
 			"",
 			"",
 			"test",
-			"\r\n--test--\r\n",
+			"--test\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n\r\n--test\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n\r\n--test--\r\n",
 			false,
 		},
 		{
@@ -229,7 +229,7 @@ func TestMailYakWriteBody(t *testing.T) {
 			"HTML",
 			"",
 			"t",
-			"--t\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/html; charset=UTF-8\r\n\r\nHTML\r\n--t--\r\n",
+			"--t\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n\r\n--t\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/html; charset=UTF-8\r\n\r\nHTML\r\n--t--\r\n",
 			false,
 		},
 		{
@@ -237,7 +237,7 @@ func TestMailYakWriteBody(t *testing.T) {
 			"",
 			"Plain",
 			"t",
-			"--t\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\nPlain\r\n--t--\r\n",
+			"--t\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\nPlain\r\n--t\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n\r\n--t--\r\n",
 			false,
 		},
 		{
@@ -307,7 +307,7 @@ func TestMailYakBuildMime(t *testing.T) {
 			"",
 			"",
 			"",
-			"From: \r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: \r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n\r\n--alt--\r\n\r\n--mixed--\r\n",
+			"From: \r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: \r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n\r\n--alt--\r\n\r\n--mixed--\r\n",
 			false,
 		},
 		{
@@ -319,7 +319,7 @@ func TestMailYakBuildMime(t *testing.T) {
 			"",
 			"",
 			"",
-			"From: \r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: \r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/html; charset=UTF-8\r\n\r\nHTML\r\n--alt--\r\n\r\n--mixed--\r\n",
+			"From: \r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: \r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/html; charset=UTF-8\r\n\r\nHTML\r\n--alt--\r\n\r\n--mixed--\r\n",
 			false,
 		},
 		{
@@ -331,7 +331,7 @@ func TestMailYakBuildMime(t *testing.T) {
 			"",
 			"",
 			"",
-			"From: \r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: \r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\nPlain\r\n--alt--\r\n\r\n--mixed--\r\n",
+			"From: \r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: \r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\nPlain\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n\r\n--alt--\r\n\r\n--mixed--\r\n",
 			false,
 		},
 		{
@@ -343,7 +343,7 @@ func TestMailYakBuildMime(t *testing.T) {
 			"",
 			"",
 			"reply",
-			"From: \r\nMime-Version: 1.0\r\nDate: " + now + "\r\nReply-To: reply\r\nSubject: \r\nTo: \r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n\r\n--alt--\r\n\r\n--mixed--\r\n",
+			"From: \r\nMime-Version: 1.0\r\nDate: " + now + "\r\nReply-To: reply\r\nSubject: \r\nTo: \r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n\r\n--alt--\r\n\r\n--mixed--\r\n",
 			false,
 		},
 		{
@@ -355,7 +355,7 @@ func TestMailYakBuildMime(t *testing.T) {
 			"",
 			"name",
 			"",
-			"From: name <>\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: \r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n\r\n--alt--\r\n\r\n--mixed--\r\n",
+			"From: name <>\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: \r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n\r\n--alt--\r\n\r\n--mixed--\r\n",
 			false,
 		},
 		{
@@ -367,7 +367,7 @@ func TestMailYakBuildMime(t *testing.T) {
 			"addr",
 			"name",
 			"",
-			"From: name <addr>\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: \r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n\r\n--alt--\r\n\r\n--mixed--\r\n",
+			"From: name <addr>\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: \r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n\r\n--alt--\r\n\r\n--mixed--\r\n",
 			false,
 		},
 		{
@@ -379,7 +379,7 @@ func TestMailYakBuildMime(t *testing.T) {
 			"from",
 			"",
 			"",
-			"From: from\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: \r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n\r\n--alt--\r\n\r\n--mixed--\r\n",
+			"From: from\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: \r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n\r\n--alt--\r\n\r\n--mixed--\r\n",
 			false,
 		},
 		{
@@ -391,7 +391,7 @@ func TestMailYakBuildMime(t *testing.T) {
 			"",
 			"",
 			"",
-			"From: \r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: subject\r\nTo: \r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n\r\n--alt--\r\n\r\n--mixed--\r\n",
+			"From: \r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: subject\r\nTo: \r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n\r\n--alt--\r\n\r\n--mixed--\r\n",
 			false,
 		},
 		{
@@ -403,7 +403,7 @@ func TestMailYakBuildMime(t *testing.T) {
 			"",
 			"",
 			"",
-			"From: \r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: one\r\nTo: two\r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n\r\n--alt--\r\n\r\n--mixed--\r\n",
+			"From: \r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: one\r\nTo: two\r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n\r\n--alt\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n\r\n--alt--\r\n\r\n--mixed--\r\n",
 			false,
 		},
 	}


### PR DESCRIPTION
Changes the MIME generation code to always include the "Content-Type"
header in each of the the MIME parts, even if the part is empty.

Previously an empty plain text or HTML body could cause some SMTP
servers to reject the mail due to the missing headers. Emails that
included both HTML and plain-text conent were not affected.

Fixes #61.
