### PR TITLE
fix: use comma separated list for To, CC, BCC headers

### DIFF
--- a/mime.go
+++ b/mime.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"mime/quotedprintable"
 	"net/textproto"
+	"strings"
 )
 
 func (m *MailYak) buildMime(w io.Writer) error {
@@ -102,18 +103,19 @@ func (m *MailYak) writeHeaders(w io.Writer) error {
 
 	fmt.Fprintf(w, "Subject: %s\r\n", m.subject)
 
-	for _, to := range m.toAddrs {
-		fmt.Fprintf(w, "To: %s\r\n", to)
+	if len(m.toAddrs) > 0 {
+		commaSeparatedToAddrs := strings.Join(m.toAddrs, ",")
+		fmt.Fprintf(w, "To: %s\r\n", commaSeparatedToAddrs)
 	}
 
-	for _, cc := range m.ccAddrs {
-		fmt.Fprintf(w, "CC: %s\r\n", cc)
+	if len(m.ccAddrs) > 0 {
+		commaSeparatedCCAddrs := strings.Join(m.ccAddrs, ",")
+		fmt.Fprintf(w, "CC: %s\r\n", commaSeparatedCCAddrs)
 	}
 
-	if m.writeBccHeader {
-		for _, bcc := range m.bccAddrs {
-			fmt.Fprintf(w, "BCC: %s\r\n", bcc)
-		}
+	if m.writeBccHeader && len(m.bccAddrs) > 0 {
+		commaSeparatedBCCAddrs := strings.Join(m.bccAddrs, ",")
+		fmt.Fprintf(w, "BCC: %s\r\n", commaSeparatedBCCAddrs)
 	}
 
 	for k, v := range m.headers {

--- a/mime_test.go
+++ b/mime_test.go
@@ -108,7 +108,7 @@ func TestMailYakWriteHeaders(t *testing.T) {
 			"",
 			"",
 			true,
-			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: test@itsallbroken.com\r\nTo: repairs@itsallbroken.com\r\n",
+			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: test@itsallbroken.com,repairs@itsallbroken.com\r\n",
 		},
 		{
 			"Single Cc address, Multiple To addresses",
@@ -118,7 +118,7 @@ func TestMailYakWriteHeaders(t *testing.T) {
 			"",
 			"",
 			true,
-			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: test@itsallbroken.com\r\nTo: repairs@itsallbroken.com\r\nCC: cc@itsallbroken.com\r\n",
+			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: test@itsallbroken.com,repairs@itsallbroken.com\r\nCC: cc@itsallbroken.com\r\n",
 		},
 		{
 			"Multiple Cc addresses, Multiple To addresses",
@@ -128,7 +128,7 @@ func TestMailYakWriteHeaders(t *testing.T) {
 			"",
 			"",
 			true,
-			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: test@itsallbroken.com\r\nTo: repairs@itsallbroken.com\r\nCC: cc1@itsallbroken.com\r\nCC: cc2@itsallbroken.com\r\n",
+			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: test@itsallbroken.com,repairs@itsallbroken.com\r\nCC: cc1@itsallbroken.com,cc2@itsallbroken.com\r\n",
 		},
 		{
 			"Single Bcc address, Multiple To addresses",
@@ -138,7 +138,7 @@ func TestMailYakWriteHeaders(t *testing.T) {
 			"",
 			"",
 			true,
-			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: test@itsallbroken.com\r\nTo: repairs@itsallbroken.com\r\nBCC: bcc@itsallbroken.com\r\n",
+			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: test@itsallbroken.com,repairs@itsallbroken.com\r\nBCC: bcc@itsallbroken.com\r\n",
 		},
 		{
 			"Multiple Bcc addresses, Multiple To addresses",
@@ -148,7 +148,7 @@ func TestMailYakWriteHeaders(t *testing.T) {
 			"",
 			"",
 			true,
-			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: test@itsallbroken.com\r\nTo: repairs@itsallbroken.com\r\nBCC: bcc1@itsallbroken.com\r\nBCC: bcc2@itsallbroken.com\r\n",
+			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: test@itsallbroken.com,repairs@itsallbroken.com\r\nBCC: bcc1@itsallbroken.com,bcc2@itsallbroken.com\r\n",
 		},
 		{
 			"Multiple Bcc addresses, Multiple To addresses",
@@ -158,7 +158,7 @@ func TestMailYakWriteHeaders(t *testing.T) {
 			"",
 			"",
 			false,
-			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: test@itsallbroken.com\r\nTo: repairs@itsallbroken.com\r\n",
+			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: test@itsallbroken.com,repairs@itsallbroken.com\r\n",
 		},
 		{
 			"All together now",
@@ -168,7 +168,7 @@ func TestMailYakWriteHeaders(t *testing.T) {
 			"",
 			"",
 			true,
-			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: test@itsallbroken.com\r\nTo: repairs@itsallbroken.com\r\nCC: cc1@itsallbroken.com\r\nCC: cc2@itsallbroken.com\r\nBCC: bcc1@itsallbroken.com\r\nBCC: bcc2@itsallbroken.com\r\n",
+			"From: Dom <dom@itsallbroken.com>\r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: test@itsallbroken.com,repairs@itsallbroken.com\r\nCC: cc1@itsallbroken.com,cc2@itsallbroken.com\r\nBCC: bcc1@itsallbroken.com,bcc2@itsallbroken.com\r\n",
 		},
 	}
 	for _, tt := range tests {
@@ -403,7 +403,7 @@ func TestMailYakBuildMime(t *testing.T) {
 			"",
 			"",
 			"",
-			"From: \r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: one\r\nTo: two\r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n\r\n--mixed--\r\n",
+			"From: \r\nMime-Version: 1.0\r\nDate: " + now + "\r\nSubject: \r\nTo: one,two\r\nContent-Type: multipart/mixed;\r\n\tboundary=\"mixed\"; charset=UTF-8\r\n\r\n--mixed\r\nContent-Type: multipart/alternative;\r\n\tboundary=\"alt\"\r\n\r\n\r\n--mixed--\r\n",
 			false,
 		},
 	}


### PR DESCRIPTION
This is a fix for #70.  Rather than multiple headers, it uses a comma separated list.
- modified the test cases with multiple addresses to expect comma separated lists
- verified that all tests pass 
