### PR TITLE
ci: bump golangci version

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -23,5 +23,3 @@ jobs:
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.32

--- a/attachments.go
+++ b/attachments.go
@@ -60,7 +60,7 @@ func (m *MailYak) AttachWithMimeType(name string, r io.Reader, mimeType string) 
 // Files can be referenced by their name within the email using the cid URL
 // protocol:
 //
-// 		<img src="cid:myFileName"/>
+//	<img src="cid:myFileName"/>
 //
 // r is not read until Send is called and the MIME type will be detected
 // using https://golang.org/pkg/net/http/#DetectContentType
@@ -80,7 +80,7 @@ func (m *MailYak) AttachInline(name string, r io.Reader) {
 // Files can be referenced by their name within the email using the cid URL
 // protocol:
 //
-// 		<img src="cid:myFileName"/>
+//	<img src="cid:myFileName"/>
 //
 // r is not read until Send is called.
 func (m *MailYak) AttachInlineWithMimeType(name string, r io.Reader, mimeType string) {

--- a/mailyak.go
+++ b/mailyak.go
@@ -40,12 +40,12 @@ const mailDateFormat = time.RFC1123Z
 //
 // host must include the port number (i.e. "smtp.itsallbroken.com:25")
 //
-//      mail := mailyak.New("smtp.itsallbroken.com:25", smtp.PlainAuth(
-//          "",
-//          "username",
-//          "password",
-//          "smtp.itsallbroken.com",
-//      ))
+//	mail := mailyak.New("smtp.itsallbroken.com:25", smtp.PlainAuth(
+//	    "",
+//	    "username",
+//	    "password",
+//	    "smtp.itsallbroken.com",
+//	))
 //
 // MailYak instances created with New will switch to using TLS after connecting
 // if the remote host supports the STARTTLS command. For an explicit TLS
@@ -67,12 +67,12 @@ func New(host string, auth smtp.Auth) *MailYak {
 //
 // host must include the port number (i.e. "smtp.itsallbroken.com:25")
 //
-//      mail := mailyak.NewWithTLS("smtp.itsallbroken.com:25", smtp.PlainAuth(
-//          "",
-//          "username",
-//          "password",
-//          "smtp.itsallbroken.com",
-//      ), tlsConfig)
+//	mail := mailyak.NewWithTLS("smtp.itsallbroken.com:25", smtp.PlainAuth(
+//	    "",
+//	    "username",
+//	    "password",
+//	    "smtp.itsallbroken.com",
+//	), tlsConfig)
 //
 // If tlsConfig is nil, a sensible default is generated that can connect to
 // host.

--- a/sender_test.go
+++ b/sender_test.go
@@ -274,7 +274,7 @@ func TestSMTPProtocolExchange(t *testing.T) {
 
 		conn, err := l.Accept()
 		if err != nil {
-			t.Fatal(err)
+			panic(err)
 		}
 		defer conn.Close()
 

--- a/setters.go
+++ b/setters.go
@@ -42,7 +42,7 @@ func (m *MailYak) To(addrs ...string) {
 //		"two@itsallbroken.com"
 //	}
 //
-// 	mail.Bcc(bccs...)
+//	mail.Bcc(bccs...)
 func (m *MailYak) Bcc(addrs ...string) {
 	m.bccAddrs = []string{}
 
@@ -64,15 +64,14 @@ func (m *MailYak) Bcc(addrs ...string) {
 //
 // Specifically, RFC822 says:
 //
-// 		Some  systems  may choose to include the text of the "Bcc" field only in the
-// 		author(s)'s  copy,  while  others  may also include it in the text sent to
-// 		all those indicated in the "Bcc" list.
+//	Some  systems  may choose to include the text of the "Bcc" field only in the
+//	author(s)'s  copy,  while  others  may also include it in the text sent to
+//	all those indicated in the "Bcc" list.
 //
 // This ambiguity can result in some SMTP servers not stripping the BCC header
 // and exposing the BCC addressees to recipients. For more information, see:
 //
-// 		https://github.com/domodwyer/mailyak/issues/14
-//
+//	https://github.com/domodwyer/mailyak/issues/14
 func (m *MailYak) WriteBccHeader(shouldWrite bool) {
 	m.writeBccHeader = shouldWrite
 }
@@ -90,7 +89,7 @@ func (m *MailYak) WriteBccHeader(shouldWrite bool) {
 //		"two@itsallbroken.com"
 //	}
 //
-// 	mail.Cc(ccs...)
+//	mail.Cc(ccs...)
 func (m *MailYak) Cc(addrs ...string) {
 	m.ccAddrs = []string{}
 
@@ -115,7 +114,7 @@ func (m *MailYak) From(addr string) {
 //
 // If set, emails typically display as being from:
 //
-// 		From Name <sender@example.com>
+//	From Name <sender@example.com>
 //
 // If name contains non-ASCII characters, it is Q-encoded according to RFC1342.
 func (m *MailYak) FromName(name string) {


### PR DESCRIPTION
Remove the golangci version pin to unblock CI.

---

* ci: bump golangci version (4d0d2d2)


* test: panic in testing goroutine (23296ca)

      Panic in the test goroutines, instead of calling t.Fatal (which is racy).

* style: gofmt (c9babb3)


