### PR TITLE
Allow specifying a recipient name

### DIFF
--- a/mailyak.go
+++ b/mailyak.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
+	"net/mail"
 	"net/smtp"
 	"regexp"
 	"strings"
@@ -177,9 +178,9 @@ func (m *MailYak) getToAddrs() []string {
 	addrs := len(m.toAddrs) + len(m.ccAddrs) + len(m.bccAddrs)
 	out := make([]string, 0, addrs)
 
-	out = append(out, m.toAddrs...)
-	out = append(out, m.ccAddrs...)
-	out = append(out, m.bccAddrs...)
+	out = append(out, stripNames(m.toAddrs)...)
+	out = append(out, stripNames(m.ccAddrs)...)
+	out = append(out, stripNames(m.bccAddrs)...)
 
 	return out
 }
@@ -193,4 +194,27 @@ func (m *MailYak) getFromAddr() string {
 // getAuth should return the smtp.Auth if configured, nil if not.
 func (m *MailYak) getAuth() smtp.Auth {
 	return m.auth
+}
+
+// stripNames returns a new slice with only the email parts from the RFC 5322 addresses.
+//
+// Or in other words, converts:
+// ["a@example.com", "John <b@example.com>", "invalid"]
+// to
+// ["a@example.com", "b@example.com"].
+//
+// Addresses that don't comply with the RFC 5322 format are skipped.
+func stripNames(addresses []string) []string {
+	result := make([]string, 0, len(addresses))
+
+	for _, item := range addresses {
+		addr, err := mail.ParseAddress(item)
+		if err != nil {
+			continue
+		}
+
+		result = append(result, addr.Address)
+	}
+
+	return result
 }

--- a/mailyak_test.go
+++ b/mailyak_test.go
@@ -58,3 +58,35 @@ func TestMailYakDate(t *testing.T) {
 		t.Errorf("MailYak.Send(): timestamp not updated: %v", dateOne)
 	}
 }
+
+// TestStripNames ensures that the stripNames() method correctly
+// remove the name part of a list of RFC 5322 addresses.
+func TestStripNames(t *testing.T) {
+	addresses := []string{
+		"a@example.com",
+		"b@example.com",
+		"invalid1",
+		"John Doe <c@example.com>",
+		"<d@example.com>",
+		"invalid2",
+	}
+
+	expected := map[string]struct{}{
+		"a@example.com": struct{}{},
+		"b@example.com": struct{}{},
+		"c@example.com": struct{}{},
+		"d@example.com": struct{}{},
+	}
+
+	result := stripNames(addresses)
+
+	if len(result) != len(expected) {
+		t.Fatalf("stripNames: Expected %d addresses, got %d: \n%v", len(expected), len(result), result)
+	}
+
+	for _, addr := range result {
+		if _, ok := expected[addr]; !ok {
+			t.Errorf("stripNames: Address %q was not expected", addr)
+		}
+	}
+}

--- a/sender_test.go
+++ b/sender_test.go
@@ -128,7 +128,7 @@ type mockMail struct {
 // toAddrs should return a slice of email addresses to be added to the RCPT
 // TO command.
 func (m *mockMail) getToAddrs() []string {
-	return m.toAddrs
+	return stripNames(m.toAddrs)
 }
 
 // fromAddr should return the address to be used in the MAIL FROM command.
@@ -182,7 +182,7 @@ func TestSMTPProtocolExchange(t *testing.T) {
 				toAddrs: []string{
 					"to@example.org",
 					"another@example.com",
-					"dom@itsallbroken.com",
+					"Dom <dom@itsallbroken.com>",
 				},
 				fromAddr: "from@example.org",
 				mime:     "bananas",

--- a/setters.go
+++ b/setters.go
@@ -12,7 +12,7 @@ import "mime"
 //
 //	tos := []string{
 //		"one@itsallbroken.com",
-//		"two@itsallbroken.com"
+//		"John Doe <two@itsallbroken.com>"
 //	}
 //
 //	mail.To(tos...)
@@ -39,7 +39,7 @@ func (m *MailYak) To(addrs ...string) {
 //
 //	bccs := []string{
 //		"one@itsallbroken.com",
-//		"two@itsallbroken.com"
+//		"John Doe <two@itsallbroken.com>"
 //	}
 //
 //	mail.Bcc(bccs...)
@@ -86,7 +86,7 @@ func (m *MailYak) WriteBccHeader(shouldWrite bool) {
 //
 //	ccs := []string{
 //		"one@itsallbroken.com",
-//		"two@itsallbroken.com"
+//		"John Doe <two@itsallbroken.com>"
 //	}
 //
 //	mail.Cc(ccs...)

--- a/setters_test.go
+++ b/setters_test.go
@@ -18,14 +18,19 @@ func TestMailYakTo(t *testing.T) {
 		want []string
 	}{
 		{
-			"Single email",
+			"Single email (without name)",
 			[]string{"dom@itsallbroken.com"},
 			[]string{"dom@itsallbroken.com"},
 		},
 		{
+			"Single email (with name)",
+			[]string{"Dom <dom@itsallbroken.com>"},
+			[]string{"Dom <dom@itsallbroken.com>"},
+		},
+		{
 			"Multiple email",
-			[]string{"dom@itsallbroken.com", "ohnoes@itsallbroken.com"},
-			[]string{"dom@itsallbroken.com", "ohnoes@itsallbroken.com"},
+			[]string{"Dom <dom@itsallbroken.com>", "ohnoes@itsallbroken.com"},
+			[]string{"Dom <dom@itsallbroken.com>", "ohnoes@itsallbroken.com"},
 		},
 		{
 			"Empty last",
@@ -68,14 +73,19 @@ func TestMailYakBcc(t *testing.T) {
 		want []string
 	}{
 		{
-			"Single email",
+			"Single email (without name)",
 			[]string{"dom@itsallbroken.com"},
 			[]string{"dom@itsallbroken.com"},
 		},
 		{
+			"Single email (with name)",
+			[]string{"Dom <dom@itsallbroken.com>"},
+			[]string{"Dom <dom@itsallbroken.com>"},
+		},
+		{
 			"Multiple email",
-			[]string{"dom@itsallbroken.com", "ohnoes@itsallbroken.com"},
-			[]string{"dom@itsallbroken.com", "ohnoes@itsallbroken.com"},
+			[]string{"Dom <dom@itsallbroken.com>", "ohnoes@itsallbroken.com"},
+			[]string{"Dom <dom@itsallbroken.com>", "ohnoes@itsallbroken.com"},
 		},
 		{
 			"Empty last",
@@ -105,6 +115,62 @@ func TestMailYakBcc(t *testing.T) {
 		})
 	}
 }
+
+func TestMailYakCc(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		// Test description.
+		name string
+		// Parameters.
+		addrs []string
+		// Want
+		want []string
+	}{
+		{
+			"Single email (without name)",
+			[]string{"dom@itsallbroken.com"},
+			[]string{"dom@itsallbroken.com"},
+		},
+		{
+			"Single email (with name)",
+			[]string{"Dom <dom@itsallbroken.com>"},
+			[]string{"Dom <dom@itsallbroken.com>"},
+		},
+		{
+			"Multiple email",
+			[]string{"Dom <dom@itsallbroken.com>", "ohnoes@itsallbroken.com"},
+			[]string{"Dom <dom@itsallbroken.com>", "ohnoes@itsallbroken.com"},
+		},
+		{
+			"Empty last",
+			[]string{"dom@itsallbroken.com", "ohnoes@itsallbroken.com", ""},
+			[]string{"dom@itsallbroken.com", "ohnoes@itsallbroken.com"},
+		},
+		{
+			"Empty Middle",
+			[]string{"dom@itsallbroken.com", "", "ohnoes@itsallbroken.com"},
+			[]string{"dom@itsallbroken.com", "ohnoes@itsallbroken.com"},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := &MailYak{
+				ccAddrs:   []string{},
+				trimRegex: regexp.MustCompile("\r?\n"),
+			}
+			m.Cc(tt.addrs...)
+
+			if !reflect.DeepEqual(m.ccAddrs, tt.want) {
+				t.Errorf("%q. MailYak.Cc() = %v, want %v", tt.name, m.ccAddrs, tt.want)
+			}
+		})
+	}
+}
+
 func TestMailYakSubject(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This PR is supposed to "fix" #74 by allowing specifying an optional name part and email with angle brackets (eg. `John Doe <test@example.com>`) in the To/Cc/Bcc addresses slice.

The change should be backward compatible (previously if someone tried to specify an email in angle brackets it failed with 501 error because the net/smtp always wrap with `<...>` the Rcpt value).

I've tested it with gmail and mailtrap and both doesn't seem to complain (note that the format `name <email>` is allowed in the RFC 5322).