### PR TITLE
ci: install goimports

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: install go-imports
-      run: go get golang.org/x/tools/cmd/goimports
+      run: go install golang.org/x/tools/cmd/goimports@latest
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.0


### PR DESCRIPTION
Fix CI.

---

* ci: install goimports (8a58ffd)
      
      Use "go install" instead of "go get".