### PR TITLE
feat: support setting custom sender domain

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,13 +27,13 @@ output:
 
 linters:
   enable:
-    - golint
+    - revive
     - gosec
     - unconvert
     - gocyclo
     - goimports
     - nakedret
-    - scopelint
+    - exportloopref
     - exhaustive
     - exportloopref
 

--- a/mailyak.go
+++ b/mailyak.go
@@ -16,6 +16,7 @@ type MailYak struct {
 	html  BodyPart
 	plain BodyPart
 
+	localName      string
 	toAddrs        []string
 	ccAddrs        []string
 	bccAddrs       []string
@@ -168,6 +169,12 @@ func (m *MailYak) HTML() *BodyPart {
 // Plain returns a BodyPart for the plain-text email body.
 func (m *MailYak) Plain() *BodyPart {
 	return &m.plain
+}
+
+// getLocalName should return the sender domain to be used in the EHLO/HELO
+// command.
+func (m *MailYak) getLocalName() string {
+	return m.localName
 }
 
 // getToAddrs should return a slice of email addresses to be added to the

--- a/sender.go
+++ b/sender.go
@@ -51,7 +51,9 @@ func smtpExchange(m sendableMail, conn net.Conn, serverName string, tryTLSUpgrad
 	defer func() { _ = c.Quit() }()
 
 	if localName := m.getLocalName(); localName != "" {
-		c.Hello(localName)
+		if err := c.Hello(localName); err != nil {
+			return err
+		}
 	}
 
 	if tryTLSUpgrade {

--- a/sender.go
+++ b/sender.go
@@ -16,6 +16,10 @@ type emailSender interface {
 
 // sendableMail provides a set of methods to describe an email to a SMTP server.
 type sendableMail interface {
+	// getLocalName should return the sender domain to be used in the EHLO/HELO
+	// command.
+	getLocalName() string
+
 	// getToAddrs should return a slice of email addresses to be added to the
 	// RCPT TO command.
 	getToAddrs() []string
@@ -45,6 +49,10 @@ func smtpExchange(m sendableMail, conn net.Conn, serverName string, tryTLSUpgrad
 		return err
 	}
 	defer func() { _ = c.Quit() }()
+
+	if localName := m.getLocalName(); localName != "" {
+		c.Hello(localName)
+	}
 
 	if tryTLSUpgrade {
 		if ok, _ := c.Extension("STARTTLS"); ok {

--- a/setters.go
+++ b/setters.go
@@ -144,3 +144,13 @@ func (m *MailYak) Subject(sub string) {
 func (m *MailYak) AddHeader(name, value string) {
 	m.headers[m.trimRegex.ReplaceAllString(name, "")] = mime.QEncoding.Encode("UTF-8", m.trimRegex.ReplaceAllString(value, ""))
 }
+
+// LocalName sets the sender domain name.
+//
+// If set, it is used in the EHLO/HELO command instead of the default domain
+// (localhost, see [smtp.NewClient]). Some SMTP servers, such as the Gmail
+// SMTP-relay, requires a proper domain name and will reject attempts to use
+// localhost.
+func (m *MailYak) LocalName(name string) {
+	m.localName = m.trimRegex.ReplaceAllString(name, "")
+}

--- a/setters_test.go
+++ b/setters_test.go
@@ -301,3 +301,44 @@ func TestMailYakAddHeader(t *testing.T) {
 		})
 	}
 }
+
+func TestMailYakLocalName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		// Test description.
+		name string
+		// Parameters.
+		from string
+		// Want
+		want string
+	}{
+		{
+			"empty",
+			"",
+			"",
+		},
+		{
+			"ASCII",
+			"example.com\r\n",
+			"example.com",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := &MailYak{
+				headers:   map[string]string{},
+				trimRegex: regexp.MustCompile("\r?\n"),
+			}
+
+			m.LocalName(tt.from)
+
+			if !reflect.DeepEqual(m.localName, tt.want) {
+				t.Errorf("%q. MailYak.LocalName() = %v, want %v", tt.name, m.localName, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Some SMTP servers, such as the Gmail SMTP-relay, requires a proper
domain name in the inital EHLO/HELO exchange and will reject attempts to
use localhost.

<!-- 

Thanks for opening a PR! Seriously, it's awesome, thank you!

To make sure this is as easy as possible, please make sure:

	* There are no breaking changes
	* Your change has tests
	* Existing tests pass
	* You've run the static analysis lints!

The lints run as part of the CI process so they need to pass before the PR can
be merged. If you want to run them locally too see below.

Please delete this template and write your PR message :)

Thanks again!




---

If you want to run the lints locally, they are executed as pre-commit hooks and
are managed with https://pre-commit.com

Once pre-commit is installed, add the hooks to this repo:

```bash
dom:mailyak%  pre-commit install -t pre-commit
dom:mailyak%  pre-commit install -t pre-push
dom:mailyak%  pre-commit install -t post-checkout
```

They will then check any commits you make from now on :)

If you want to quickly run them without committing something, just run
`pre-commit run --all`

-->
